### PR TITLE
add a browser testing checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ A guide for front-end development at the [CFPB](http://cfpb.github.io/).
 - [Publishing node modules](npm.md)
 - [Building your project's front-end](build.md)
 
+## Tools
+
+- [ESLint file](.eslintrc)
+- [Browser testing checklist](browser-checklist.md)
+
 ## Our Core Values
 
 - **Service**: We value that what we do is being of service to consumers, customers, and internal partners

--- a/browser-checklist.md
+++ b/browser-checklist.md
@@ -1,0 +1,26 @@
+## Browsers
+
+- [ ] Chrome
+- [ ] Safari
+- [ ] FF
+- [ ] IE10
+- [ ] IE9
+- [ ] IE8
+- [ ] IE7
+- [ ] Opera
+- [ ] iOS8
+- [ ] Android 5
+- [ ] Blackberry Bold
+
+## Accessibility
+
+- [ ] Keyboard friendly
+- [ ] Screen reader friendly
+
+## Other
+
+- [ ] Is useable without CSS
+- [ ] Is useable without JS
+- [ ] Flexible from small to large screens
+- [ ] No linting errors or warnings
+- [ ] JavaScript tests are passing

--- a/browser-checklist.md
+++ b/browser-checklist.md
@@ -3,6 +3,7 @@
 - [ ] Chrome
 - [ ] Safari
 - [ ] FF
+- [ ] IE11
 - [ ] IE10
 - [ ] IE9
 - [ ] IE8
@@ -10,6 +11,7 @@
 - [ ] Opera
 - [ ] iOS8
 - [ ] Android 5
+- [ ] Chrome for Android
 - [ ] Blackberry Bold
 
 ## Accessibility
@@ -22,5 +24,3 @@
 - [ ] Is useable without CSS
 - [ ] Is useable without JS
 - [ ] Flexible from small to large screens
-- [ ] No linting errors or warnings
-- [ ] JavaScript tests are passing


### PR DESCRIPTION
This adds the browser testing checklist from the Capital Framework docs. Once we all agree on this document, I'll update the docs to point to it so that we have a single source of truth.