### PR TITLE
Fix tab width in .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -376,7 +376,7 @@ rules:
   # Set a specific tab width for your code.
   indent:
     - 2
-    - 4
+    - 2
     -
       indentSwitchCase: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 All notable changes to this project will be documented in this file.
 
+## 2015-04-30
+
+### Fixed
+
+- `.eslintrc`: default tab width set to two space
+
 ## 2015-04-08
 
 ### Added


### PR DESCRIPTION
Changed it from 4 spaces to 2 spaces.

Review: @Scotchester @ascott1 