### PR TITLE
Fix PR Template Link

### DIFF
--- a/code-reviews.md
+++ b/code-reviews.md
@@ -90,7 +90,7 @@ Before seeking a review, you should be able to check off each of the following:
 ### Opening a PR
 
 Once sure your code meets the checks above, open a Pull Request for your new
-feature or bugfix following our [PR Template](https://raw.githubusercontent.com/cfpb/front-end/733397192b04551d56c847f3416b0bcdf5bab544/pr-template.md). Remember that the
+feature or bugfix following our [PR Template](https://raw.githubusercontent.com/cfpb/front-end/master/pr-template.md). Remember that the
 more information you provide to reviewers, the more context they will have. This
 leads to faster reviews, and less back and forth between everyone.
 


### PR DESCRIPTION
I noticed Scott's changes in #43 wasn't showing up in the guide. This fixes that and should keep the code review guide in line with the latest changes to the Pull Request template.