### PR TITLE
Updates ESLint config to 0.21.0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,13 +1,45 @@
+# Enable ecmascript 6 features.
 ecmaFeatures:
-  ecmascript: 6
+  arrowFunctions: false
+  binaryLiterals: false
+  blockBindings: false
+  classes: false
+  defaultParams: false
+  destructuring: false
+  forOf: true
+  generators: false
+  modules: false
+  objectLiteralComputedProperties: false
+  objectLiteralDuplicateProperties: false
+  objectLiteralShorthandMethods: false
+  objectLiteralShorthandProperties: false
+  octalLiterals: false
+  regexUFlag: false
+  regexYFlag: false
+  spread: false
+  superInFunctions: false
+  templateStrings: false
+  unicodeCodePointEscapes: false
+  globalReturn: false
+  jsx: true
+
+parser: espree
 
 env:
   browser: true
   node: true
+  amd: true
+  mocha: false
+  jasmine: false
+  phantomjs: true
+  jquery: false
+  prototypejs: false
+  shelljs: false
+  meteor: false
+  es6: false
 
 globals:
-  jQuery: true
-  $: true
+# No globals outside of env settings.
 
 # Linting rules for ESLint.
 # 0's ignore a rule, 1's produce a warning, and 2's throw an error.
@@ -38,8 +70,14 @@ rules:
   # Enforces flagging use of the debugger.
   no-debugger: 2
 
+  # Disallow duplicate arguments in functions.
+  no-dupe-args: 2
+
   # Disallows duplicate keys when creating object literals.
   no-dupe-keys: 2
+
+  # Disallow a duplicate case label.
+  no-duplicate-case: 2
 
   # Disallows empty statements.
   no-empty: 2
@@ -138,6 +176,11 @@ rules:
     -
       allowKeywords: false
       allowPattern: ''
+
+  # Enforces consistent newlines before or after dots.
+  dot-location:
+    - 2
+    - property
 
   # Enforces use of === and !== over == and !=.
   eqeqeq:
@@ -261,6 +304,7 @@ rules:
     - 1
     -
       terms:
+        - '@todo'
         - todo
         - fixme
         - xxx
@@ -416,7 +460,7 @@ rules:
   eol-last: 2
 
   # Enforce function expressions not having a name.
-  func-names: 1
+  func-names: 0
 
   # Enforce use of function declarations or expressions
   # because of variable hoisting behavior.
@@ -431,6 +475,10 @@ rules:
       align: value
       beforeColon: false
       afterColon: true
+
+  # Disallow mixed 'LF' and 'CRLF' as linebreaks.
+  linebreak-style:
+    - unix
 
   # Specify the maximum depth callbacks can be nested.
   max-nested-callbacks:
@@ -449,8 +497,16 @@ rules:
   # Disallows omission of parentheses when invoking a constructor with no arguments.
   new-parens: 2
 
+  # Disallow an empty newline after var statement.
+  newline-after-var:
+    - 0
+    - always
+
   # Disallows use of the Array constructor.
   no-array-constructor: 2
+
+  # Disallow use of the continue statement.
+  no-continue: 1
 
   # Disallows inline after code.
   no-inline-comments: 1
@@ -486,16 +542,27 @@ rules:
   # Disallows dangling underscores in identifiers.
   no-underscore-dangle: 0
 
+  # Disallow the use of Boolean literals in conditional expressions.
+  no-unneeded-ternary: 0
+
   # Disallows wrapping of non-IIFE statements in parens.
   no-wrap-func: 2
 
   # Disallows multiple var statements per function.
-  one-var: 0
+  one-var:
+    - 0
+    - always
 
   # Requires assignment operator shorthand or prohibit it entirely.
   operator-assignment:
     - 2
     - always
+
+
+  # Enforce operators to be placed before or after line breaks.
+  operator-linebreak:
+    - 1
+    - after
 
   # Enforces padding within blocks.
   padded-blocks:
@@ -549,14 +616,24 @@ rules:
   space-in-brackets:
     - 1
     - always
+    -
+      singleValue: true
+      objectsInArrays: false
+      arraysInArrays: false
+      arraysInObjects: false
+      objectsInObjects: false
+      propertyName: false
 
   # Requires spaces inside parentheses.
   space-in-parens:
     - 1
-    - never
+    - always
 
   # Requires spaces around operators.
-  space-infix-ops: 2
+  space-infix-ops:
+    - 2
+    -
+      int32Hint: false
 
   # Requires a space after return, throw, and case.
   space-return-throw-case: 2
@@ -588,6 +665,11 @@ rules:
   generator-star-spacing:
     - 2
     - before
+
+  # Require method and property shorthand syntax for object literals.
+  object-shorthand:
+    - 0
+    - always
 
 
   # Rules for LEGACY SUPPORT.


### PR DESCRIPTION
Updates ESLint config for ESLint 0.21.0.

## Additions

- Lists the JS parser used as `espree`.
- Adds additional environments supported by ESLint. `browser`, `node`, `amd`, and `phantomjs` are `true` to enable global values for `console`, `require`, etc., but everything else is off. Individual projects might want to set `jquery: true` here, but I'd err on the side of discouraging global jQuery, so set it to `false`.
- Adds `no-dupe-args` rule and enforces it.
- Adds `no-duplicate-case` and enforces it.
- Adds `dot-location` and enforces it on the property line. This means the period goes on it's own line when chaining methods. E.g.:
  ```
// yes
something
  .that()
    .does()
       .something();

// no
something.
  not().
    this().
       way();
```
- Adds `@todo` to the `no-warning-comments` rule to pick up TODO comments in jsdoc comments.
- Adds `linebreak-style` rule and enforces it on `unix` line breaks. This can be an issue when committing code from multiple platforms and can lead to weird errors that aren't visible when opening in a text editor.
- Adds `newline-after-var` rule but doesn't enforce it. I found this rule not to be smart enough. I suspect it will develop further in the future. It would be nice to enforce a newline after vars in the root level of a module, but not within functions that only span 2-3 lines, which isn't currently possible with this rule.
- Adds `no-continue` rule and sets it to warning, as is consistent with the console rule warning.
- Adds `no-unneeded-ternary` rule but doesn't enforce it. This rule seems too strict as it requires code that could be expressed in one line to create two additional vars when a boolean is used.
- Adds `always` option to `one-var` rule for always enforcing one variable declaration per scope. However, this just adds the option and leaves the rule unenforced.
- Adds `operator-linebreak` rule and warns for having the operator at the end of a line of code after a line break (see note below).
- Adds exception options to `space-in-brackets` rule, and only sets a single value between a bracket as the exception.
- Adds option to `space-infix-ops` rule for int32 syntax without a space (`a|0`), but sets it to `false` (the default) till it's needed.
- Adds `object-shorthand` rule but doesn't enforce it as it's an ES6 feature.

## Removals

- Removes all globals. If jQuery globals are needed, set the jQuery `env` setting to `true`.

## Changes

- `ecmaFeatures` config is no longer one value, but a series of flags that can enable or disable ES6 features. These are all off to begin with till ES6 is more supported, with the exception of the usage of `for… of` loops and `jsx` (for React).
- Relaxes `func-names` rule. In theory this is a nice to have, but it's not worth the extra work of what it provides. Making all functions have names means they will be named in call-stacks, but dev tools are good at looking up a function call location, so this really isn't necessary and adds a lot of weight to code to name all anonymous functions. Projects still can name anonymous function if they want, but they won't be checked.
- Changes `space-in-parens` to `always` for consistency with `space-in-brackets`.

## Testing

- Lint some JS with this and it should load with latest ESLint version.

## Review

- @ascott1 
- @wpears
- @mistergone

## Notes

- `operator-linebreak` rule setting was chosen based on existing conventions in place, however it's arguably inconsistent with `dot-location`. E.g. it enforces the reverse setup:
 
 ```
// yes
var fullHeight = borderTop +
                 innerHeight +
                 borderBottom;
// no
var fullHeight = borderTop
               + innerHeight
               + borderBottom;
```