### PR TITLE
Adding `VariableDeclarator: true` to allow left align declaration values

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -245,6 +245,7 @@ rules:
       exceptions:
         BinaryExpression: false
         Property: true
+        VariableDeclarator: true
 
   # Disallows use of multiline strings with a trailing backslash.
   # This rule is needed for ECMAScript environments earlier than 5.


### PR DESCRIPTION
Adding `VariableDeclarator: true` to allow left align declaration values

Ex.
```
  opts            = opts || {};
  this.match      = false;
  this.breakpoint = opts.breakpoint;
  this.enter      = opts.enter;
  this.leave      = opts.leave;
  this.type       = opts.type || 'max';
```

## Additions

- Adds `VariableDeclarator: true` to `no-multi-spaces:` ruleset.

## Testing

`eslint` should not return errors when values are left aligned.

## Review

- @ascott1 
- @anselmbradford 
- @wpears 
- @mistergone 

[Preview this PR without the whitespace changes](?w=0)

## Notes

Couldn't find a rule on this in the playbook, figured a PR is worthy place to discuss if left aligned values should be allowed by default or rather a personal preference left to each project.