### PR TITLE
Relaxes key-spacing rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -470,7 +470,7 @@ rules:
 
   # Enforce spacing between keys and values in object literal properties.
   key-spacing:
-    - 2
+    - 1
     -
       align: value
       beforeColon: false

--- a/.eslintrc
+++ b/.eslintrc
@@ -558,7 +558,6 @@ rules:
     - 2
     - always
 
-
   # Enforce operators to be placed before or after line breaks.
   operator-linebreak:
     - 1


### PR DESCRIPTION
Relaxes key-spacing rule to warning for consistency with space-in-parens and space-in-bracket settings.

## Changes

- Changes key-spacing to warning.
- Removes unneeded newline.

## Testing

- Misalignment of property values in an object literal should throw a warning, not an error, and thus won't break a build.

## Review

- @ascott1 
- @wpears 
- @mistergone 
