### PR TITLE
Relaxes complexity setting to 4

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -156,7 +156,7 @@ rules:
   # Enforces specific maximum cyclomatic complexity.
   complexity:
     - 1
-    - 3
+    - 4
 
   # Enforces return statements to either always or never specify values.
   consistent-return: 2


### PR DESCRIPTION
Relaxes complexity setting to 4 to allow for switch statements and certain if statement structures.

A cyclomatic complexity of 3 allows:

```js
if (arg1 === true) { … }
else if (arg2 === true { … }
else { … }
```

However, there are circumstances where it's not desirable to have a catch-all else block at the end, and instead the following is needed:

```js
if (arg1 === true) { … }
else if (arg2 === true) { … }
else if (arg3 === true) { … }
```

This has a cyclomatic complexity of 4, presumably because there's an implicit ending else statement that could be present. This also applies to `switch` statements, which have an implicit "default" block that will increment the complexity by one.

This PR proposes raising the cyclomatic complexity threshold to 4 to allow for three route if/else blocks without a catch-all else block at the end.

## Changes

- Changes ESLint `complexity` threshold from `3` to `4`.

## Testing

```js
if (arg1 === true) { … }
else if (arg2 === true) { … }
else if (arg3 === true) { … }
```

Should not throw an ESLint warning.

## Review

- @ascott1 
- @wpears 
- @mistergone 
