### PR TITLE
Add jQuery to list of allowed globals

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -39,7 +39,7 @@ env:
   es6: false
 
 globals:
-# No globals outside of env settings.
+  $: false
 
 # Linting rules for ESLint.
 # 0's ignore a rule, 1's produce a warning, and 2's throw an error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 All notable changes to this project will be documented in this file.
 
+## 2015-06-02
+
+### Added
+
+- Added jQuery to list of allowed globals in `.eslintrc`
+
 ## 2015-05-06
 
 ### Added


### PR DESCRIPTION
Implements the fix @sephcoster found today. I just ran into the same bug while working on the generator.

## Changes

- Adds jQuery to list of allowed globals in `.eslintrc`.
- Updates changelog appropriately.

## Review

- @sephcoster 
- @anselmbradford 
- @jimmynotjim 

## Notes

- Setting it to `false` checks that your code doesn't overwrite `$`.