### PR TITLE
Add PR submitter checklist to Pull Request template

### DIFF
--- a/code-reviews.md
+++ b/code-reviews.md
@@ -107,6 +107,8 @@ When reviewing code, you should be able to check off each of the following:
 - [ ] Is the usage of each function clear?
 - [ ] Have edge cases been considered and tested for?
 
+Use this bookmarklet code to add this checklist to your Pull Request comments: [Code Review Checklist](https://gist.github.com/cfarm/a4174fe6f775353a3115)
+
 ### Commenting on code
 
 When commenting on breaks to our style guide, reviewers should include a link back

--- a/pr-template.md
+++ b/pr-template.md
@@ -2,43 +2,40 @@ Short description explaining the high-level reason for the pull request
 
 ## Additions
 
-- List of additions made
-- To the project
-- Within this PR
+- 
 
 ## Removals
 
-- List of removals made
-- To the project
-- Within this PR
+- 
 
 ## Changes
 
-- List of changes made
-- To the project
-- Within this PR
+- 
 
 ## Testing
 
-- List of site urls
-- Or actions to take
-- To test the changes made
+- 
 
 ## Review
 
 - @user
-- @user
-- @user
 
-## Preview
+## Screenshots
 
-Include any screenshots that will make reviewing/testing easier
 
-[Preview this PR without the whitespace changes](?w=0)
 
-## Notes
+## Todos
 
-- List of notes about the changes that might be necessary
-- For the reviewer to know ahead of time or of related Github issues
-- Ex. Known issues or items outside the scope of the review
-- Ex. Fixes #100
+- 
+
+## Checklist
+
+* [ ] Changes are limited to a single goal (no scope creep)
+* [ ] Code can be automatically merged (no conflicts)
+* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
+* [ ] Passes all existing automated tests
+* [ ] New functions include new tests
+* [ ] New functions are documented (with a description, list of inputs, and expected output)
+* [ ] Placeholder code is flagged
+* [ ] Visually tested in supported browsers and devices 
+* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)


### PR DESCRIPTION
Add our PR submitter checklist to the Pull Request template so we can easily check off the requirements of each PR when we submit it.


## Additions

- PR checklist for submitter
- added a link in our Code Review standards to bookmarklet code for checklists reviewers and for submitters in Gists (should we add these to the repo?)

## Removals

- removed placeholder text from the PR template, so it's easier to copy, paste, update.

## Changes

- changed "Notes" to "Todos" since that's how I've been using it. I put any generic "notes" in the intro paragraph. Todos is for upcoming related PRs, or tasks to finish in the PR.

## Testing

- save bookmarklet code to your browser bar, try to make a PR with it.

## Review

- @ascott1 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices 
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

