### PR TITLE
Add credit for quote from idiomatic.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 # CFPB front-end team
 
 A guide for front-end development at the [CFPB](http://cfpb.github.io/).
- 
+
 ## Standards and styles
 
 > All code in any code-base should look like a single person typed it, no matter how many people contributed.
+> - [idiomatic.js](https://github.com/rwaldron/idiomatic.js/#all-code-in-any-code-base-should-look-like-a-single-person-typed-it-no-matter-how-many-people-contributed)
 
 - [Markup standards](markup.md)
 - [CSS/Less standards](css.md)


### PR DESCRIPTION
I think the quote is fantastic. But since some folks might not be familiar with where it comes from, we should add a link crediting idiomatic.js.

## Additions

- Added line crediting idiomatic.js for quote on our standard guidelines

## Preview

[Preview this PR without the whitespace changes](?w=0)