### PR TITLE
Tweak indent rules for multi-line var declarations

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -534,11 +534,10 @@ rules:
     - 2
     -
       SwitchCase: 1
-      VariableDeclarator: {
-        "var": 2,
-        "let": 2,
-        "const": 3
-      }
+      VariableDeclarator:
+        var: 2
+        let: 2
+        const: 3
 
   # Enforce spacing between keys and values in object literal properties.
   key-spacing:

--- a/.eslintrc
+++ b/.eslintrc
@@ -534,7 +534,11 @@ rules:
     - 2
     -
       SwitchCase: 1
-      VariableDeclarator: 1
+      VariableDeclarator: {
+        "var": 2,
+        "let": 2,
+        "const": 3
+      }
 
   # Enforce spacing between keys and values in object literal properties.
   key-spacing:


### PR DESCRIPTION
With new `indent` option `VariableDeclarator` set to `1`, ESLint was requiring that multiline variable declarations have their additional lines be indented by only 2 spaces. This change will allow us to continue to align the variable names (at 4 spaces for `var` and `let` declarations, and 6 spaces for `const` declarations).

## Review
- @anselmbradford 
- @ascott1 