### PR TITLE
add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cfpb-front-end",
   "version": "1.0.0",
-  "description": "Front-end files and resources for the CFPB team",
+  "description": "Front-end files and resources for the CFPB front-end development team",
   "main": " ",
   "scripts": {
     "test": " "

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
     "url": "git+https://github.com/cfpb/front-end.git"
   },
   "keywords": [
+    "cfpb",
     "standards",
     "eslint",
-    "gitignore"
+    "gitignore",
+    "play book"
   ],
   "author": "CFPB",
   "license": "CC0-1.0",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "cfpb-front-end",
+  "version": "1.0.0",
+  "description": "Front-end files and resources for the CFPB team",
+  "main": " ",
+  "scripts": {
+    "test": " "
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cfpb/front-end.git"
+  },
+  "keywords": [
+    "standards",
+    "eslint",
+    "gitignore"
+  ],
+  "author": "CFPB",
+  "license": "CC0-1.0",
+  "bugs": {
+    "url": "https://github.com/cfpb/front-end/issues"
+  },
+  "homepage": "https://github.com/cfpb/front-end#readme"
+}


### PR DESCRIPTION
To make our front-end guide npm installable with `npm install cfpb-front-end`.