### PR TITLE
Update README with full list of links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 All notable changes to this project will be documented in this file.
 
+## 2015-09-22
+
+### Changed
+
+- Updated `README` with full list of links.
+
+
 ## 2015-07-06
 
 ### Changed
@@ -70,4 +77,3 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Nothing.
-

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ A guide for front-end development at the [CFPB](http://cfpb.github.io/).
 > All code in any code-base should look like a single person typed it, no matter how many people contributed.
 > - [idiomatic.js](https://github.com/rwaldron/idiomatic.js/#all-code-in-any-code-base-should-look-like-a-single-person-typed-it-no-matter-how-many-people-contributed)
 
-- [Markup standards](markup.md)
 - [CSS/Less standards](css.md)
 - [JavaScript standards](javascript.md)
+- [Markup standards](markup.md)
 
 ## Capital Framework
 
@@ -21,14 +21,18 @@ Capital Framework is our modular front end framework.
 
 ## Guides
 
+- [Accessibility](accessibility.md)
 - [Building your project's front-end](build.md)
 - [Code review guide](code-reviews.md)
+- [CommonJS Modules](javascript-modules-commonjs.md)
 - [Publishing node modules](npm.md)
+- [Testing](testing.md)
 
 ## Tools
 
-- [ESLint file](.eslintrc)
 - [Browser testing checklist](browser-checklist.md)
+- [ESLint file](.eslintrc)
+- [gitignore sample](.gitignore)
 - [Pull request template](https://raw.githubusercontent.com/cfpb/front-end/master/pr-template.md)
 
 ## Our Core Values

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Capital Framework is our modular front end framework.
 - **Willingness**: We are willing to help each other with anything that is good for the team
 - **Excellence**: We believe that excellence is defined by a commitment to and practice of constant learning and improvement
 
+## This guide is npm installable!
+
+```
+npm install cfpb-front-end
+```
+
 
 ## Open source licensing info
 1. [TERMS](TERMS.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cfpb-front-end",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Front-end files and resources for the CFPB front-end development team",
   "main": " ",
   "scripts": {


### PR DESCRIPTION
This adds any missing links to the TOC in the README, alphabetizes those links, adds a note about npm, and bumps this to 1.1.0 as there are several unpublished changes not in npm.

## Review

@cfpb/front-end-team-admin 