### PR TITLE
Update quote-props to "consistent as needed"

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -686,7 +686,7 @@ rules:
   # Requires quotes around object literal property names.
   quote-props:
     - 1
-    - as-needed
+    - consistent-as-needed
     -
       keywords: true
       unnecessary: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 All notable changes to this project will be documented in this file.
 
+## 2015-09-28
+
+### Changed
+
+- Updated ESLint quote-props to "consistent-as-needed"
+
 ## 2015-09-22
 
 ### Changed


### PR DESCRIPTION
Currently our rule is to only use quotes when absolutely necessary. This can produce some funky results, like: 

```javascript

{
  rule:               false
  'hyphenated-rule':  true
}
```

This updates the rule to be consistent within each object, which seems reasonable to me.

Thoughts?

## Review

@anselmbradford 
@wpears 