### PR TITLE
Relax key-spacing slightly

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -563,9 +563,9 @@ rules:
   key-spacing:
     - 1
     -
-      align: value
       beforeColon: false
       afterColon: true
+      mode: minimal
 
   # Enforces empty lines around comments.
   lines-around-comment:


### PR DESCRIPTION
The `key-spacing` rule can get a bit funky when properties in an object have other objects as values, reading to less readability than before the rule is applied! It also can cause issues with exceeding the max line length when it otherwise wouldn't if alignment was not happening on the property values. This tweak makes property keys have *at least* 1 space after the colon, allowing the values to aligned when it makes sense, or not when it doesn't.


## Review

- @ascott1  
- @wpears 
- @mistergone 