### PR TITLE
Restore link to review PR wo whitespace changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,8 @@ Short description explaining the high-level reason for the pull request
 
 - @user
 
+[Preview this PR without the whitespace changes](?w=0)
+
 ## Screenshots
 
 


### PR DESCRIPTION
#Somewhere along the line of updates to this template, we lost the link to view a PR without whitespace changes.

## Additions

- A link to view the created PR without whitespace changes.

## Testing

- Standard PR view with lots of whitespace changes: https://[GHE]/CCDB4/CCDB-content/pull/54
- Preview that PR without the whitespace changes: https://[GHE]/CCDB4/CCDB-content/pull/54?w=0

## Review

- @jimmynotjim

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)