### PR TITLE
Proposal: Change CSS indentation standard to four spaces

### DIFF
--- a/css.md
+++ b/css.md
@@ -18,7 +18,7 @@ such that it's highly readable and consistent across different developers on a t
 
 ## General Practices
 
-- Use soft-tabs with a two space indent
+- Use soft-tabs with a four-space indent
 - One line per selector
 - Always end property declarations with a semicolon
 - Put spaces after `:` in property declarations


### PR DESCRIPTION
Following the discussion that recently arose in the Atomic Design channel, I propose changing our official CSS (or Less) indentation standard to four spaces.

## Reasoning

- Most of our CSS codebase is already indenting at four spaces, so it'd be a smaller change to make the two-space code we have match the four-space code.
  - I don't have data to back this up, just my impression from having seen a large proportion of the CSS we've written here over time, but I am pretty confident in this assertion. Feel free to prove me wrong.
- There's very little danger of long line lengths in CSS, so no need to save characters.
- Four-space indentation is our standard for HTML and Python, as well.

## Review

- @cfpb/front-end-team-admin 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

