### PR TITLE
Add deadline + assignment standards

### DIFF
--- a/code-reviews.md
+++ b/code-reviews.md
@@ -45,8 +45,9 @@ accomplish this, everyone should follow these tips.
 
 ### For code submitters
 
-- Assign one reviewer to your pull request using Github's interface.
-- Reminder reviewers to respond within 1 week, otherwise you are free to merge the PR if you receive no feedback.
+- Assign one reviewer to your pull request using GitHub's interface.
+- One :+1: comment from the reviewer indicates the Pull Request should be merged.
+- Remind reviewers to respond within 1 week, otherwise you are free to merge the PR if you receive no feedback.
 - Link to the code review from the originating Jira task/issue, if applicable.
 - Remember that the code isn't you, don't get defensive when a reviewer is critical
   of the code.
@@ -61,7 +62,7 @@ accomplish this, everyone should follow these tips.
 
 ### For code reviewers
 
-- Review the code, make comments, or and/or merge within 1 week of being assigned a pull request.
+- Review the code, make comments, and/or merge within 1 week of being assigned a pull request.
 - Understand why the code is necessary (bug, user experience, refactoring)
 - Seek to understand the author's perspective.
 - Clearly communicate which ideas you feel strongly about and those you don't.
@@ -69,8 +70,8 @@ accomplish this, everyone should follow these tips.
 - Offer alternative implementations, but assume the author already considered
   them. ("What do you think about such-and-such here?")
 - If discussions turn too philosophical or academic, move the discussion to a new
-  issue or offline. In the meantime, the author has the final say on the current
-  implementation.
+  issue or offline. In the meantime, the **author has the final say on the current
+  implementation**.
 - Avoid focusing on trivial issues. This is often termed [bike-shedding](https://en.wikipedia.org/wiki/Law_of_triviality).
 - Sign off on the pull request with a :thumbsup: or "Ready to merge" comment.
 - Wait to merge the branch until it has passed Continuous Integration testing.

--- a/code-reviews.md
+++ b/code-reviews.md
@@ -45,6 +45,8 @@ accomplish this, everyone should follow these tips.
 
 ### For code submitters
 
+- Assign one reviewer to your pull request using Github's interface.
+- Reminder reviewers to respond within 1 week, otherwise you are free to merge the PR if you receive no feedback.
 - Link to the code review from the originating Jira task/issue, if applicable.
 - Remember that the code isn't you, don't get defensive when a reviewer is critical
   of the code.
@@ -59,6 +61,7 @@ accomplish this, everyone should follow these tips.
 
 ### For code reviewers
 
+- Review the code, make comments, or and/or merge within 1 week of being assigned a pull request.
 - Understand why the code is necessary (bug, user experience, refactoring)
 - Seek to understand the author's perspective.
 - Clearly communicate which ideas you feel strongly about and those you don't.


### PR DESCRIPTION
This adds standards for code review assignment + deadlines for merging PR's.

## Additions

- Recommends that a person creating a pull request assign a specific Github user to review the PR
- Recommends limiting reviewers to 1 person who will 👍  or 👎 
- Adds a 1 week deadline in which PRs can be self-merged if no feedback or comments are given.

## Notes

- We are testing this out on Capital Framework over the next few weeks, check back to see how it went.

